### PR TITLE
With setuptools 31.0.0 we have a different handling of namespace packages.

### DIFF
--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__)  # pragma: nocover


### PR DESCRIPTION
This leads to this hotfix to get 100% test coverage.